### PR TITLE
Use the new style kwarg name.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Create an Authorization token in Forecast App: https://id.getharvest.com/develop
 Create an instance of the ``forecast.Api`` using the Account ID and Authorization token::
 
     >>> import forecast
-    >>> api = forecast.Api(account_id='account_id', authorization_token='authorization_token')
+    >>> api = forecast.Api(account_id='account_id', auth_token='authorization_token')
 
 
 Example usage::


### PR DESCRIPTION
Heyo, just starting to use this libaray and saw that the `kwarg` in the README wasn't matching.

Thanks for the good work so far!